### PR TITLE
bugfix(eslint): Ensure the proper eslint version is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-eslint": "^7.2.3",
+    "eslint": "^4.0.0",
     "eslint-plugin-brackets": "^0.1.0",
     "eslint-plugin-class-property": "^1.0.6",
     "eslint-plugin-fat-arrow-same-line": "^0.1.0",


### PR DESCRIPTION
The new class properties plugin depends on eslint@3, which ends up resolving the old version at the root level. This doesn't affect ember-cli-eslint, but it would affect our tests and local editors that call the root eslint directly. Pinning the version in the config explicitly prevents this, and the class properties plugin still functions properly on v4.