### PR TITLE
refactor(base): Add base rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,11 @@ module.exports = {
       'after': true
     }],
     'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': ['error', {
+      'anonymous': 'never',
+      'named': 'never',
+      'asyncArrow': 'always'
+    }],
     'space-in-parens': ['error', 'never'],
     'space-infix-ops': 'error',
     'space-unary-ops': ['error', {

--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@ module.exports = {
     'import'
   ],
   extends: [
-    'eslint:recommended',
-    'plugin:ember-best-practices/base'
+    'eslint:recommended'
   ],
   env: {
     'browser': true,
@@ -21,14 +20,47 @@ module.exports = {
   },
   rules: {
     // ES6
+    'array-bracket-spacing': ['error', 'never'],
     'arrow-parens': ['error', 'always'],
+
+    'brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
+
     'camelcase': ['error', { 'properties': 'never' }],
-    'generator-star-spacing': ['error', {
+    'comma-dangle': ['error', 'never'],
+    'comma-spacing': ['error', {
       'before': false,
       'after': true
     }],
+    'comma-style': ['error', 'last'],
+    'curly': ['error', 'all'],
+
+    'dot-notation': 'error',
+    'dot-location': ['error', 'property'],
+
+    'eqeqeq': ['error', 'always'],
+    'eol-last': ['error', 'always'],
+
+    'func-call-spacing': ['error', 'never'],
+
+    'indent': ['error', 2, { 'SwitchCase': 1 }],
+
+    'key-spacing': ['error', {
+      'beforeColon': false,
+      'afterColon': true
+    }],
+    'keyword-spacing': ['error', {
+      'overrides': {
+        'catch': {
+          'after': false
+        }
+      }
+    }],
+
+    'max-statements-per-line': ['error', { 'max': 1 }],
+
+    'no-trailing-spaces': 'error',
+    'no-empty': ['error'],
     'no-var': 'error',
-    'no-useless-rename': 'error',
     'no-unused-vars': [
       'error',
       {
@@ -37,12 +69,42 @@ module.exports = {
         'ignoreRestSiblings': false
       }
     ],
+    'no-useless-rename': 'error',
+    'no-useless-concat': 'error',
+
     'object-shorthand': ['error', 'always'],
+    'object-curly-spacing': ['error', 'always'],
+    'one-var': ['error', {
+      'uninitialized': 'always',
+      'initialized': 'never'
+    }],
+    'operator-linebreak': ['error', 'before'],
+
     'prefer-const': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'eol-last': ['error', 'always'],
-    'quotes': ['error', 'single', { "allowTemplateLiterals": true, "avoidEscape": true }],
+
+    'generator-star-spacing': ['error', {
+      'before': false,
+      'after': true
+    }],
+
+    'quotes': ['error', 'single', { 'avoidEscape': true }],
+
+    'semi': ['error', 'always'],
+    'semi-spacing': ['error', {
+      'before': false,
+      'after': true
+    }],
+    'space-before-blocks': ['error', 'always'],
+    'space-before-function-paren': ['error', 'never'],
+    'space-in-parens': ['error', 'never'],
+    'space-infix-ops': 'error',
+    'space-unary-ops': ['error', {
+      'words': true,
+      'nonwords': false
+    }],
+    'spaced-comment': ['error', 'always'],
 
     // Overrides for Ember
     'new-cap': ['error', {


### PR DESCRIPTION
@Addepar/ice 

Turns out the base eslint config in `ember-best-practices` isn't available for export anywhere. This PR adds most of the basic rules from there and ember-suave, with a few exceptions:

* Left out `no-multiline`, it's pointless and doesn't allow devs to format code into more readable chunks.
* Added `eqeqeq`, we should never use double equals and if we do it should have an `eslint-disable` and a comment explaining why
* Allow blocks to be single like: `if (foo) { return; }` is a nice brief pattern to be able to have